### PR TITLE
feature: 스프링 시큐리티 기본 설정

### DIFF
--- a/src/main/java/site/dbgn/security/config/SecurityConfig.java
+++ b/src/main/java/site/dbgn/security/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package site.dbgn.security.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private static final String[] WEB_SECURITY_WHITE_LIST = {"/", "/login*", "oauth2*", "/error*"};
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /*
+     * 일반적인 정적자원들의 보안설정 해제
+     */
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(auth -> auth
+                        .requestMatchers(WEB_SECURITY_WHITE_LIST).permitAll()
+                        .anyRequest().authenticated())
+                .formLogin(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(AbstractHttpConfigurer::disable);
+
+        return http.getOrBuild();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #3 

## 📝작업 내용

- 앤드포인트 {"/", "/login*", "oauth2*", "/error*"} 로는 모든 사용자 접근 가능
- 나머지 앤드포인트는 인증된 사용자만 접근 가능
- 정적자원들은 권한심사 하지 않도록 설정(API서버라 일반적으로 필요없을 것 같지만, 개발자 로컬환경 고려하여 설정하였습니다.)
- PasswordEncoder는 BCryptPasswordEncoder를 사용합니다. (레퍼런스가 가장 많음)
- 개발편의를 위해 CSRF설정은 OFF합니다. (추후 논의하여 활성화할 것인지는 검토 필요해보입니다.)

## 💬리뷰 요구사항(선택)
